### PR TITLE
Fix: Restore UI styling and adjust asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>월별 일정 및 출석 관리</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.ico" type="image/svg+xml">
     <link rel="manifest" href="manifest.json">

--- a/manifest.json
+++ b/manifest.json
@@ -2,19 +2,19 @@
   "name": "월별 일정 및 출석 관리",
   "short_name": "일정관리 PWA",
   "description": "오프라인 지원 월별 일정 생성 및 출석 관리 PWA",
-  "start_url": "/SUNGDANG/index.html",
+  "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#007bff",
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/SUNGDANG/icons/icon-192x192.png",
+      "src": "./icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/SUNGDANG/icons/icon-512x512.png",
+      "src": "./icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
This commit addresses issues arising after the initial fixes:

1.  **Restore Tailwind CSS CDN**: I re-added the Tailwind CSS CDN script tag to `index.html`. This is an immediate fix to restore the application's design and menu, which were broken when the CDN was previously removed. Instructions for a proper production Tailwind setup remain in README.md for future implementation.

2.  **Revert Manifest Paths to Relative**: I changed `start_url` and icon `src` paths in `manifest.json` back to relative paths (e.g., `./index.html`, `./icons/icon-192x192.png`). This is an attempt to resolve the persistent manifest icon loading error, considering the service worker's scope and potential issues with how absolute paths were being resolved in the GitHub Pages environment. The `favicon.ico` link in `index.html` was confirmed to be using a relative path.