### PR TITLE
Fix: Resolve 'deleteAllParticipants' TypeError and adjust calendar he…

### DIFF
--- a/db.js
+++ b/db.js
@@ -125,6 +125,22 @@ export async function deleteMultipleParticipants(ids) {
     });
 }
 
+export async function deleteAllParticipants() {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction([PARTICIPANTS_STORE_NAME], 'readwrite');
+        const store = transaction.objectStore(PARTICIPANTS_STORE_NAME);
+        const request = store.clear(); // Clears all records from the store
+
+        request.onsuccess = () => {
+            resolve();
+        };
+        request.onerror = (event) => {
+            console.error('Error deleting all participants:', event.target.error);
+            reject(event.target.error);
+        };
+    });
+}
 
 export async function saveSchedule(year, month, scheduleData) {
     const db = await openDB();

--- a/schedule_generation_ui.js
+++ b/schedule_generation_ui.js
@@ -141,7 +141,7 @@ function renderCalendar(year, month, scheduleData) {
     const headerRow = document.createElement('tr');
     KOREAN_DAYS.forEach(day => {
         const th = document.createElement('th');
-        th.className = 'px-3 py-3 text-center text-xs font-medium text-slate-500 uppercase tracking-wider';
+        th.className = 'px-3 py-1 text-center text-xs font-medium text-slate-500 uppercase tracking-wider';
         th.textContent = day;
         headerRow.appendChild(th);
     });


### PR DESCRIPTION
…ader

This commit addresses two issues:

1.  **Fix 'db.deleteAllParticipants is not a function' TypeError**:
    *   The `deleteAllParticipants` function was found to be missing from `db.js`.
    *   This commit adds the `export async function deleteAllParticipants()` to `db.js`, enabling the "Delete All" functionality in the Master Data view to work correctly.

2.  **Reduce Schedule Generation Calendar Header Height**:
    *   Modified `schedule_generation_ui.js` to reduce the vertical padding of the header cells (Sun-Sat) in the schedule generation calendar.
    *   Changed the Tailwind CSS class from `py-3` to `py-1` for these cells, resulting in a shorter header row.