### PR TITLE
Hotfix: `schedule_generation_logic.js`에서 'j is not defined' 오류를 수정했습니다.

### DIFF
--- a/schedule_generation_logic.js
+++ b/schedule_generation_logic.js
@@ -256,8 +256,8 @@ export async function generateSchedule(year, month) {
                         if (!candidate1 || dailyAssignments.has(candidate1.id)) continue; // Already checked in filter, but good for safety
                         p1Obj = candidate1;
 
-                        for (let j = i + 1; j < sortedTargetPool.length; j++) {
-                            const candidate2 = sortedTargetPool[(effectiveCurrentIndex + j) % sortedTargetPool.length];
+                        for (let p2LoopIdx = i + 1; p2LoopIdx < sortedTargetPool.length; p2LoopIdx++) {
+                            const candidate2 = sortedTargetPool[(effectiveCurrentIndex + p2LoopIdx) % sortedTargetPool.length];
                             if (!candidate2 || dailyAssignments.has(candidate2.id) || candidate2.id === p1Obj.id) continue;
                             if (candidate2.gender === p1Obj.gender) {
                                 p2Obj = candidate2;
@@ -266,7 +266,7 @@ export async function generateSchedule(year, month) {
                         }
                         if (p1Obj && p2Obj) {
                             assignedPair = [p1Obj.id, p2Obj.id];
-                            effectiveCurrentIndex = (effectiveCurrentIndex + Math.max(i,j) + 1); // Advance index past used pair
+                            effectiveCurrentIndex = (effectiveCurrentIndex + Math.max(i, p2LoopIdx) + 1); // Advance index past used pair
                              if (slotInfo.categoryKey === 'elementary_6am') scheduleIndices[sequentialStateKeys.elementary_6am] = effectiveCurrentIndex;
                              else scheduleIndices[sequentialStateKeys.middle_7am] = effectiveCurrentIndex;
                             break;


### PR DESCRIPTION
`schedule_generation_logic.js` 파일의 `generateSchedule` 함수에서 순차적으로 할당하는 로직에 문제가 있었습니다. 두 번째 참가자(`p2Obj`)를 찾는 내부 반복문에서 인덱스 변수를 잘못 참조하여
`ReferenceError: j is not defined` 오류가 발생했습니다.

이번 변경으로 다음과 같이 오류를 해결했습니다:
-   내부 반복문의 인덱스 변수 이름을 `j`에서 `p2LoopIdx`로 더 명확하게 바꿨습니다.
-   반복문 안에서 `p2LoopIdx`를 사용하여 배열 요소에 접근하고, `effectiveCurrentIndex`를 업데이트하도록 수정했습니다.

이렇게 수정하여 일정 생성 시 발생하던 스크립트 오류를 해결했습니다.