### PR TITLE
Hotfix: `schedule_generation_logic.js` 파일의 'p2LoopIdx is not defined'…

### DIFF
--- a/schedule_generation_logic.js
+++ b/schedule_generation_logic.js
@@ -255,18 +255,21 @@ export async function generateSchedule(year, month) {
                         const candidate1 = sortedTargetPool[(effectiveCurrentIndex + i) % sortedTargetPool.length];
                         if (!candidate1 || dailyAssignments.has(candidate1.id)) continue; // Already checked in filter, but good for safety
                         p1Obj = candidate1;
+                        let foundP2OriginalIndex = -1; // Variable to store the successful p2LoopIdx
 
                         for (let p2LoopIdx = i + 1; p2LoopIdx < sortedTargetPool.length; p2LoopIdx++) {
                             const candidate2 = sortedTargetPool[(effectiveCurrentIndex + p2LoopIdx) % sortedTargetPool.length];
                             if (!candidate2 || dailyAssignments.has(candidate2.id) || candidate2.id === p1Obj.id) continue;
                             if (candidate2.gender === p1Obj.gender) {
                                 p2Obj = candidate2;
+                                foundP2OriginalIndex = p2LoopIdx; // Store the index when p2 is found
                                 break;
                             }
                         }
                         if (p1Obj && p2Obj) {
                             assignedPair = [p1Obj.id, p2Obj.id];
-                            effectiveCurrentIndex = (effectiveCurrentIndex + Math.max(i, p2LoopIdx) + 1); // Advance index past used pair
+                            // Use foundP2OriginalIndex which is in the correct scope
+                            effectiveCurrentIndex = (effectiveCurrentIndex + Math.max(i, foundP2OriginalIndex) + 1);
                              if (slotInfo.categoryKey === 'elementary_6am') scheduleIndices[sequentialStateKeys.elementary_6am] = effectiveCurrentIndex;
                              else scheduleIndices[sequentialStateKeys.middle_7am] = effectiveCurrentIndex;
                             break;


### PR DESCRIPTION
… 오류를 수정했습니다.

이전 커밋에서 'j is not defined' 오류를 수정하는 과정에서 발생한 또 다른 `ReferenceError`인 'p2LoopIdx is not defined'를 해결했습니다.

`schedule_generation_logic.js` 파일 내 `generateSchedule` 함수의 순차 배정 로직에서, `p2Obj` (두 번째 참가자)를 찾는 내부 중첩 루프의 카운터 변수 (`p2LoopIdx`)가 루프 스코프를 벗어난 후 `effectiveCurrentIndex` 업데이트 로직에서 참조되려 하여 오류가 발생했습니다.

수정 사항:
-   `p1Obj`를 찾는 외부 루프 내에 `foundP2OriginalIndex` 변수를 추가로 선언했습니다.
-   `p2Obj`를 찾는 내부 루프에서 `p2Obj`를 성공적으로 찾았을 때, 해당 시점의 `p2LoopIdx` 값을 `foundP2OriginalIndex`에 저장합니다.
-   `effectiveCurrentIndex` 업데이트 시, `p2LoopIdx` 대신 `foundP2OriginalIndex` 값을 사용하도록 수정했습니다.

이 변경으로 순차 배정 로직 내 변수 스코프 문제가 해결되어 일정 생성 시 발생하던 스크립트 오류가 해결됩니다.