### PR TITLE
Fix: prevMonthAbsentees 초기화 오류 수정 및 일정 초기화 기능 확장

### DIFF
--- a/schedule_generation_logic.js
+++ b/schedule_generation_logic.js
@@ -118,7 +118,17 @@ export async function generateSchedule(year, month) {
         calculatedPrevTotalCounts.set(p.id, calculatePrevTotalCount(p.id));
     });
 
-    const daysInMonth = new Date(year, month, 0).getDate(); // Moved daysInMonth up for totalCoreSlots calc
+    // Initialize prevMonthAbsentees and fixedAbsenteeAssignments here
+    const prevMonthDateForAbsenteeFetch = new Date(year, month - 1, 0);
+    const prevYearForAbsenteeFetch = prevMonthDateForAbsenteeFetch.getFullYear();
+    const prevMonthForAbsenteeFetch = prevMonthDateForAbsenteeFetch.getMonth() + 1;
+    const prevMonthAbsenteesList = await db.getAbsenteesForMonth(prevYearForAbsenteeFetch, prevMonthForAbsenteeFetch);
+    const prevMonthAbsentees = new Set(prevMonthAbsenteesList); // Now prevMonthAbsentees is defined
+
+    const fixedAbsenteeAssignments = new Map(); // Declare here
+    prevMonthAbsentees.forEach(id => fixedAbsenteeAssignments.set(id, 0)); // Initialize based on defined prevMonthAbsentees
+
+    const daysInMonth = new Date(year, month, 0).getDate();
 
     let totalCoreSlots = { elementary_6am: 0, middle_7am: 0 };
     for (let dayIter = 1; dayIter <= daysInMonth; dayIter++) { // Renamed day to dayIter to avoid conflict
@@ -186,10 +196,7 @@ export async function generateSchedule(year, month) {
     const absenteeFixedWeeklyAssignments = new Map(); // participantId -> Set of week numbers for fixed assignments this month
     participants.forEach(p => absenteeFixedWeeklyAssignments.set(p.id, new Set()));
     
-    const fixedAbsenteeAssignments = new Map(); 
-    const prevMonthAbsenteesList = await db.getAbsenteesForMonth(new Date(year, month - 1, 0).getFullYear(), new Date(year, month - 1, 0).getMonth() + 1);
-    const prevMonthAbsentees = new Set(prevMonthAbsenteesList);
-    prevMonthAbsentees.forEach(id => fixedAbsenteeAssignments.set(id, 0));
+    // Removed fixedAbsenteeAssignments and prevMonthAbsentees related code from here. It will be added earlier.
 
     const sequentialStateKeys = {
         'elementary_6am': 'idx_elem_6am',


### PR DESCRIPTION
이번 커밋은 두 가지 주요 사항을 해결합니다:

1.  **`Cannot access 'prevMonthAbsentees' before initialization` 오류 수정**:
    *   `schedule_generation_logic.js` 파일 내 `generateSchedule` 함수에서, `prevMonthAbsentees` 변수가 초기화되기 전에 참조되어 발생하던 `ReferenceError`를 수정했습니다.
    *   `prevMonthAbsentees` 관련 변수들의 선언 및 초기화 코드 블록을 해당 변수들이 처음 사용되는 시점보다 앞서 실행되도록 코드 순서를 조정했습니다.

2.  **일정 초기화 시 출석 기록도 함께 초기화하는 기능 추가**:
    *   `schedule_generation_ui.js`의 "이번 달 일정 초기화" (쓰레기통 아이콘) 기능을 확장했습니다.
    *   이제 해당 월의 일정 데이터를 초기화할 뿐만 아니라, `attendance_logic.js`의 `clearAllAbsencesInView` 함수를 호출하여 해당 월의 모든 결석 기록을 출석으로 처리(기록된 결석 로그 삭제)합니다.
    *   여러분에게 표시되는 확인 메시지와 작업 완료 메시지에 이러한 변경 사항이 명시적으로 안내됩니다.