### PR TITLE
Fix: 달력 UI 개선 및 공유 이미지 '오늘' 강조 제거

### DIFF
--- a/schedule_generation_ui.js
+++ b/schedule_generation_ui.js
@@ -300,14 +300,17 @@ function renderCalendar(year, month, scheduleData) {
     const firstDayOfMonth = new Date(year, month - 1, 1).getDay(); // 0 (Sun) - 6 (Sat)
 
     const table = document.createElement('table');
-    table.className = 'min-w-full divide-y divide-slate-200 border border-slate-200';
+    // min-w-full removed, width: 100% will be handled by style.css
+    table.className = 'divide-y divide-slate-200 border border-slate-200';
 
     const thead = document.createElement('thead');
     thead.className = 'bg-slate-50';
     const headerRow = document.createElement('tr');
     KOREAN_DAYS.forEach(day => {
         const th = document.createElement('th');
-        th.className = 'px-3 py-1 text-center text-xs font-medium text-slate-500 uppercase tracking-wider';
+        // px-3 changed to px-2 for less horizontal padding
+        th.className = 'px-2 py-1 text-center text-xs font-medium text-slate-500 uppercase tracking-wider';
+        th.style.width = `${100 / 7}%`; // Distribute width equally
         th.textContent = day;
         headerRow.appendChild(th);
     });

--- a/share_ui.js
+++ b/share_ui.js
@@ -177,10 +177,12 @@ function renderShareCalendar(year, month, scheduleDays, participantsList) {
                     dayNumberDiv.style.fontWeight = '700'; // font-bold
                     dayNumberDiv.style.lineHeight = '1'; // leading-none
                     dayNumberDiv.style.padding = '0px'; // Reset padding
+                    dayNumberDiv.classList.add('today-number-highlight'); // 식별용 클래스 추가
 
                     cell.style.borderColor = '#7dd3fc'; // sky-300
                     cell.style.borderWidth = '2px';
                     cell.style.borderStyle = 'solid';
+                    cell.classList.add('today-cell-highlight'); // 식별용 클래스 추가
                 }
 
                 const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(date).padStart(2, '0')}`;
@@ -312,7 +314,31 @@ async function handleDownload() {
                     clonedCalendarContainer.style.margin = '0';
                     clonedCalendarContainer.style.padding = '0';
                 }
-                // 스타일 변경 없이 원본 그대로 유지
+
+                // '오늘' 강조 스타일 제거 로직 추가
+                const todayCellClones = documentClone.querySelectorAll('.today-cell-highlight');
+                todayCellClones.forEach(cellClone => {
+                    cellClone.style.borderColor = '#e2e8f0'; // 기본 slate-200 색상
+                    cellClone.style.borderWidth = '1px';   // 기본 테두리 두께
+                    // cellClone.style.borderStyle = 'solid'; // 이미 solid일 것이므로 생략 가능
+                });
+
+                const todayNumberClones = documentClone.querySelectorAll('.today-number-highlight');
+                todayNumberClones.forEach(numDivClone => {
+                    numDivClone.style.color = '#64748b'; // 기본 slate-500 색상 (날짜 숫자)
+                    numDivClone.style.backgroundColor = 'transparent'; // 배경 없음
+                    numDivClone.style.borderRadius = ''; // 원형 배경 제거
+                    numDivClone.style.width = 'auto'; // 자동 너비
+                    numDivClone.style.height = 'auto'; // 자동 높이
+                    numDivClone.style.display = 'block'; // flex 해제, 기본 block으로
+                    numDivClone.style.textAlign = 'right'; // 원래 정렬 유지
+                    numDivClone.style.marginLeft = ''; // 자동 마진 해제
+                    numDivClone.style.fontWeight = '600'; // 기본 font-semibold
+                    numDivClone.style.lineHeight = '';    // 기본값 사용
+                    numDivClone.style.padding = ''; // 기본 패딩 사용
+                    // numDivClone.style.paddingRight = '0.25rem'; // 원래 있던 패딩 유지 가능
+                    // numDivClone.style.paddingLeft = '0.25rem';
+                });
             }
         });
 

--- a/style.css
+++ b/style.css
@@ -138,7 +138,8 @@ label {
 /* Schedule Generation Calendar Styles (Preserved) */
 #schedule-calendar-display table {
     width: 100%;
-    table-layout: auto; /* Changed from fixed */
+    table-layout: fixed; /* Changed from fixed */
+    border-collapse: collapse; /* Added for explicitness */
     /* min-width: 800px; /* Removed or commented out */
 }
 #schedule-calendar-display td {


### PR DESCRIPTION
이번 커밋은 여러분의 피드백에 따른 두 가지 UI 및 기능 개선 사항을 포함합니다:

1.  **일정 생성 달력 모바일 UI 개선**:
    *   `schedule_generation_ui.js` 및 `style.css`를 수정하여 "일정 생성" 화면의 달력이 모바일 환경에서 가로 스크롤 없이 한 화면에 모두 표시되도록 개선했습니다.
    *   달력 테이블에 `table-layout: fixed` 및 `width: 100%`를 적용하고, 각 요일 헤더(`th`)의 너비를 균등하게 배분했습니다.
    *   셀 패딩을 조정하여 내용이 넘치지 않도록 했습니다.

2.  **공유 달력 이미지 다운로드 시 '오늘' 강조 제거**:
    *   `share_ui.js`의 달력 이미지 다운로드 기능을 수정하여, 생성되는 이미지에서 '오늘' 날짜를 강조하는 스타일(배경색, 테두리 등)이 제거되도록 했습니다.
    *   `renderShareCalendar` 함수에서 '오늘' 날짜 관련 요소에 식별용 클래스를 추가하고, `handleDownload` 함수의 `html2canvas` `onclone` 콜백에서 이 클래스를 사용하여 복제된 DOM의 스타일을 이미지 생성 전에 일시적으로 변경하는 방식을 사용했습니다.

이 변경으로 여러분은 모바일 환경에서 일정을 더 편리하게 확인할 수 있으며, 공유용 달력 이미지를 좀 더 일반적인 형태로 저장할 수 있게 됩니다.