### PR TITLE
Fix ReferenceError for attemptB1Successful

### DIFF
--- a/schedule_generation_logic.js
+++ b/schedule_generation_logic.js
@@ -535,7 +535,10 @@ export async function generateSchedule(year, month) {
                                     }
                                 }
                             });
-                            if ((isElementaryCoreSlot || isMiddleCoreSlot) && !attemptB1Successful ) {
+                            // If it's a core slot and still not filled by specific A/B1/B2 logic,
+                            // this general sequential assignment will count towards core slots.
+                            // The !attemptB1Successful flag was removed as it's no longer relevant.
+                            if (isElementaryCoreSlot || isMiddleCoreSlot) {
                                if (slotInfo.categoryKey === CORE_CATEGORIES.elementary) assignedCoreSlotsCount.elementary_6am++;
                                else if (slotInfo.categoryKey === CORE_CATEGORIES.middle) assignedCoreSlotsCount.middle_7am++;
                             }


### PR DESCRIPTION
A previous commit inadvertently commented out the assignment to `attemptB1Successful` in the B-1 stage, but a downstream reference to this variable remained in the general sequential assignment logic. This caused a `ReferenceError` during schedule generation.

This commit removes the problematic `&& !attemptB1Successful` check from the conditional statement. The logic for incrementing `assignedCoreSlotsCount` is handled by the specific stage (A, B-1, B-2, or the general sequential fallback) that actually fills the slot, making this check redundant and the undefined variable problematic.