### PR TITLE
fix: Adapt UI to handle new return type from generateSchedule

### DIFF
--- a/schedule_generation_ui.js
+++ b/schedule_generation_ui.js
@@ -493,8 +493,11 @@ async function handleGenerateSchedule() {
     displayMessage('일정을 생성 중입니다...', 'info');
 
     try {
-        const scheduleData = await logic.generateSchedule(year, month);
-        renderCalendar(year, month, scheduleData);
+        const resultObject = await logic.generateSchedule(year, month); // NEW: Renamed variable
+
+        // Optional: console.log('Assignment Summary:', resultObject.assignmentSummary); // For debugging or future use
+
+        renderCalendar(year, month, resultObject.schedule); // NEW: Use resultObject.schedule
         displayMessage('일정이 성공적으로 생성되었습니다.', 'success');
     } catch (error) {
         console.error("Schedule generation failed:", error);


### PR DESCRIPTION
The `generateSchedule` function in `schedule_generation_logic.js` was previously modified to return an object containing both the schedule data and an assignment summary (i.e., `{ schedule: [], assignmentSummary: "" }`).

The UI code in `schedule_generation_ui.js` was still expecting `generateSchedule` to return the schedule data array directly. This mismatch caused a `TypeError: scheduleData?.find is not a function` when attempting to render the calendar.

This commit updates `schedule_generation_ui.js` to correctly access the `schedule` property from the object returned by `generateSchedule` before passing it to the `renderCalendar` function. This resolves the TypeError and ensures the calendar renders correctly with the generated schedule data.