### PR TITLE
fix: Remove all current date highlighting in Share Calendar

### DIFF
--- a/share_ui.js
+++ b/share_ui.js
@@ -165,24 +165,24 @@ function renderShareCalendar(year, month, scheduleDays, participantsList) {
                 cell.appendChild(dayNumberDiv);
 
                 if (isCurrentDayToday) {
-                    dayNumberDiv.style.color = '#0284c7'; // sky-600
-                    dayNumberDiv.style.backgroundColor = '#e0f2fe'; // sky-100
-                    dayNumberDiv.style.borderRadius = '9999px'; // rounded-full
-                    dayNumberDiv.style.width = '1.5rem'; // w-6
-                    dayNumberDiv.style.height = '1.5rem'; // h-6
-                    dayNumberDiv.style.display = 'flex';
-                    dayNumberDiv.style.alignItems = 'center';
-                    dayNumberDiv.style.justifyContent = 'center';
-                    dayNumberDiv.style.marginLeft = 'auto';
-                    dayNumberDiv.style.fontWeight = '700'; // font-bold
-                    dayNumberDiv.style.lineHeight = '1'; // leading-none
-                    dayNumberDiv.style.padding = '0px'; // Reset padding
-                    dayNumberDiv.classList.add('today-number-highlight'); // 식별용 클래스 추가
+                    // dayNumberDiv.style.color = '#0284c7'; // sky-600
+                    // dayNumberDiv.style.backgroundColor = '#e0f2fe'; // sky-100
+                    // dayNumberDiv.style.borderRadius = '9999px'; // rounded-full
+                    // dayNumberDiv.style.width = '1.5rem'; // w-6
+                    // dayNumberDiv.style.height = '1.5rem'; // h-6
+                    // dayNumberDiv.style.display = 'flex';
+                    // dayNumberDiv.style.alignItems = 'center';
+                    // dayNumberDiv.style.justifyContent = 'center';
+                    // dayNumberDiv.style.marginLeft = 'auto';
+                    // dayNumberDiv.style.fontWeight = '700'; // font-bold
+                    // dayNumberDiv.style.lineHeight = '1'; // leading-none
+                    // dayNumberDiv.style.padding = '0px'; // Reset padding
+                    // dayNumberDiv.classList.add('today-number-highlight'); // 식별용 클래스 추가
 
-                    cell.style.borderColor = '#7dd3fc'; // sky-300
-                    cell.style.borderWidth = '2px';
-                    cell.style.borderStyle = 'solid';
-                    cell.classList.add('today-cell-highlight'); // 식별용 클래스 추가
+                    // cell.style.borderColor = '#7dd3fc'; // sky-300
+                    // cell.style.borderWidth = '2px';
+                    // cell.style.borderStyle = 'solid';
+                    // cell.classList.add('today-cell-highlight'); // 식별용 클래스 추가
                 }
 
                 const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(date).padStart(2, '0')}`;


### PR DESCRIPTION
This commit removes all visual highlighting for the current date in the shared calendar view (`share_ui.js`).

Previously, the current date was distinguished with a sky blue border on its cell, and the date number had a sky blue background, a different text color, and bold font weight.

Based on your feedback, all these specific styling rules applied within the `renderShareCalendar` function when `isCurrentDayToday` is true have been commented out. This includes:
- Cell border color and width.
- Date number background color.
- Date number text color and font weight.
- Styles related to shaping the date number into a circle (border-radius, width, height, display, padding, etc.).
- Addition of 'today-cell-highlight' and 'today-number-highlight' classes.

As a result, the current date will now appear visually identical to any other date in the shared calendar.