### PR TITLE
style: Differentiate '중등' rows with background color in inspection table

### DIFF
--- a/schedule_generation_ui.js
+++ b/schedule_generation_ui.js
@@ -249,6 +249,14 @@ function renderInspectionTable(analysisData, uniqueCategoryKeys) { // uniqueCate
     analysisData.forEach(participantAnalysis => {
         const tr = inspectionTableBody.insertRow();
 
+        // --- Add the new conditional styling here ---
+        if (participantAnalysis.participantType === '중등') {
+            tr.style.backgroundColor = '#f1f5f9'; // This is Tailwind's slate-100 color
+        } else {
+            tr.style.backgroundColor = ''; // Ensures '초등' rows use default (e.g., white)
+        }
+        // --- End of new conditional styling ---
+
         // '초중구분' Cell
         const tdType = tr.insertCell();
         tdType.className = 'px-2 py-2 whitespace-nowrap text-sm text-slate-800';


### PR DESCRIPTION
This commit updates the `renderInspectionTable` function in `schedule_generation_ui.js` to apply a distinct background color to rows corresponding to '중등' (Middle school) participants.

Specifically, a light slate/gray background (`#f1f5f9`) is now applied via inline style to the `<tr>` elements for '중등' students. Rows for '초등' (Elementary) students will explicitly retain their default background color (e.g., white/transparent).

This change enhances the readability of the inspection table by providing a clear visual separation between the two participant types, as per your request.